### PR TITLE
feat(acm): move to zero-malloc for nominal cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "globset",
+ "smallvec",
 ]
 
 [[package]]
@@ -533,6 +534,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "svix-ksuid"

--- a/rawr-acm/Cargo.toml
+++ b/rawr-acm/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.91.0"
 # -------------------------#
 [dependencies]
 globset = "0.4"
+smallvec = "1.13"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }


### PR DESCRIPTION
swapped out the ol' veccy boi for a heckin good smallvec. we like stacky segment collects 'round these parts. mallocs are for folk who don't benchmark (jkjk).

* acm `enforce()` collects into `SmallVec`
* added `enforce_batch()` for list use-cases
* trie `contains()` collects into `SmallVec` as well

for further information, see: https://github.com/iamnande/rawr/issues/9#issuecomment-3630524681

--

results:

* nominal cases yield zero heap allocations
* latency reduced by `~30-45%` across all scenarios
* throughput increased by `~40-80%`
* all improvements are statistically significant (`p < 0.05`)

per-scenario highlights:

* simple_allow: `~44%` faster, `~80%` higher throughput
* deny_override: `~29%` faster, `~42%` higher throughput
* wildcard_glob: `~36%` faster, `~57%` higher throughput
* no_matching_policy: `~44%` faster, `~79%` higher throughput
* deep_path: `~35%` faster, `~54%` higher throughput

absolute performance:

* fast paths (literals) are at ~55–62 ns per enforcement
* more complex cases:
  * wildcard_glob: ~87 ns
  * deep_path: ~140 ns

--

CPU profiling data:

* [rawr-acm_acm.main.json](https://github.com/user-attachments/files/24208313/rawr-acm_acm.main.json)

*[rawr-acm_acm.smallvec.json](https://github.com/user-attachments/files/24208314/rawr-acm_acm.smallvec.json)

Benchmark data:

```
❯ make benchmark-acm
2025-12-17 00:32:24 -0800 [ rawr - 0.1.0 ] running rawr-acm/acm benchmarks
   Compiling smallvec v1.15.1
   Compiling rawr-acm v0.1.0 (/Users/nick@ngrok.com/src/mhq/iamnande/rawr/rawr-acm)
    Finished `bench` profile [optimized] target(s) in 1.35s
     Running benches/acm.rs (target/release/deps/acm-b0e0363c21138d69)
Gnuplot not found, using plotters backend
Benchmarking Acm::enforce/simple_allow
Benchmarking Acm::enforce/simple_allow: Warming up for 3.0000 s
Benchmarking Acm::enforce/simple_allow: Collecting 100 samples in estimated 5.0000 s (80688900 iterations)
Benchmarking Acm::enforce/simple_allow: Analyzing
Acm::enforce/simple_allow
                        time:   [60.949 ns 61.442 ns 61.948 ns]
                        thrpt:  [16.143 Melem/s 16.275 Melem/s 16.407 Melem/s]
                 change:
                        time:   [-44.815% -44.322% -43.854%] (p = 0.00 < 0.05)
                        thrpt:  [+78.106% +79.603% +81.210%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
slope  [60.949 ns 61.948 ns] R^2            [0.8588010 0.8584047]
mean   [60.844 ns 61.522 ns] std. dev.      [1.4349 ns 1.9797 ns]
median [60.615 ns 61.033 ns] med. abs. dev. [761.01 ps 2.0681 ns]
Benchmarking Acm::enforce/deny_override
Benchmarking Acm::enforce/deny_override: Warming up for 3.0000 s
Benchmarking Acm::enforce/deny_override: Collecting 100 samples in estimated 5.0002 s (81077750 iterations)
Benchmarking Acm::enforce/deny_override: Analyzing
Acm::enforce/deny_override
                        time:   [62.085 ns 62.519 ns 63.057 ns]
                        thrpt:  [15.859 Melem/s 15.995 Melem/s 16.107 Melem/s]
                 change:
                        time:   [-30.017% -29.457% -28.913%] (p = 0.00 < 0.05)
                        thrpt:  [+40.673% +41.757% +42.892%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
slope  [62.085 ns 63.057 ns] R^2            [0.8886701 0.8856738]
mean   [62.652 ns 63.394 ns] std. dev.      [1.4911 ns 2.3387 ns]
median [62.084 ns 63.007 ns] med. abs. dev. [1.2776 ns 2.1094 ns]
Benchmarking Acm::enforce/wildcard_glob
Benchmarking Acm::enforce/wildcard_glob: Warming up for 3.0000 s
Benchmarking Acm::enforce/wildcard_glob: Collecting 100 samples in estimated 5.0002 s (57463950 iterations)
Benchmarking Acm::enforce/wildcard_glob: Analyzing
Acm::enforce/wildcard_glob
                        time:   [86.416 ns 86.913 ns 87.477 ns]
                        thrpt:  [11.432 Melem/s 11.506 Melem/s 11.572 Melem/s]
                 change:
                        time:   [-36.718% -36.163% -35.618%] (p = 0.00 < 0.05)
                        thrpt:  [+55.323% +56.649% +58.024%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
slope  [86.416 ns 87.477 ns] R^2            [0.9049670 0.9038694]
mean   [85.878 ns 86.811 ns] std. dev.      [1.7592 ns 3.0123 ns]
median [85.219 ns 86.119 ns] med. abs. dev. [1.3150 ns 2.1833 ns]
Benchmarking Acm::enforce/no_matching_policy
Benchmarking Acm::enforce/no_matching_policy: Warming up for 3.0000 s
Benchmarking Acm::enforce/no_matching_policy: Collecting 100 samples in estimated 5.0001 s (87026650 iterations)
Benchmarking Acm::enforce/no_matching_policy: Analyzing
Acm::enforce/no_matching_policy
                        time:   [55.462 ns 55.585 ns 55.739 ns]
                        thrpt:  [17.941 Melem/s 17.990 Melem/s 18.030 Melem/s]
                 change:
                        time:   [-44.522% -44.137% -43.689%] (p = 0.00 < 0.05)
                        thrpt:  [+77.586% +79.010% +80.252%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
slope  [55.462 ns 55.739 ns] R^2            [0.9761960 0.9758516]
mean   [56.317 ns 57.022 ns] std. dev.      [1.5524 ns 2.0063 ns]
median [55.520 ns 56.266 ns] med. abs. dev. [576.53 ps 1.6279 ns]
Benchmarking Acm::enforce/deep_path
Benchmarking Acm::enforce/deep_path: Warming up for 3.0000 s
Benchmarking Acm::enforce/deep_path: Collecting 100 samples in estimated 5.0000 s (34476350 iterations)
Benchmarking Acm::enforce/deep_path: Analyzing
Acm::enforce/deep_path  time:   [138.45 ns 139.44 ns 140.55 ns]
                        thrpt:  [7.1150 Melem/s 7.1717 Melem/s 7.2228 Melem/s]
                 change:
                        time:   [-35.810% -35.087% -34.343%] (p = 0.00 < 0.05)
                        thrpt:  [+52.306% +54.052% +55.788%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
slope  [138.45 ns 140.55 ns] R^2            [0.8541266 0.8526172]
mean   [142.69 ns 145.93 ns] std. dev.      [5.2553 ns 11.857 ns]
median [141.48 ns 145.67 ns] med. abs. dev. [5.1662 ns 7.5744 ns]
```